### PR TITLE
[bugfix] update mongodb image from 6-jammy to 8-noble

### DIFF
--- a/xolo.yml
+++ b/xolo.yml
@@ -1,6 +1,6 @@
 services:
  xolo-db:
-  image: mongo:6-jammy
+  image: mongo:8-noble
   ports:
     - ${XOLO_MONGODB_PORT:-27018}:27017
   volumes:


### PR DESCRIPTION
I updated the ```xolo.yml``` and upgrade the docker image of mongodb 